### PR TITLE
Fix lora training for time-related parameters

### DIFF
--- a/RWKV-v4neo/cuda/wkv_cuda.cu
+++ b/RWKV-v4neo/cuda/wkv_cuda.cu
@@ -2,8 +2,8 @@
 #include <assert.h>
 
 #define MIN_VALUE (-1e38)
+typedef float F;
 
-template <typename F>
 __global__ void kernel_forward(const int B, const int T, const int C,
                                const F *__restrict__ const _w, const F *__restrict__ const _u, const F *__restrict__ const _k, const F *__restrict__ const _v,
                                F *__restrict__ const _y) {
@@ -13,7 +13,7 @@ __global__ void kernel_forward(const int B, const int T, const int C,
     const int _offset = _b * T * C + _c;
 
     F u = _u[_c];
-    F w = _w[_c];
+    F w = -exp(_w[_c]);
     const F *__restrict__ const k = _k + _offset;
     const F *__restrict__ const v = _v + _offset;
     F *__restrict__ const y = _y + _offset;

--- a/RWKV-v4neo/cuda/wkv_cuda.cu
+++ b/RWKV-v4neo/cuda/wkv_cuda.cu
@@ -41,93 +41,10 @@ __global__ void kernel_forward(const int B, const int T, const int C,
     }
 }
 
-template <typename F>
-__global__ void kernel_backward(const int B, const int T, const int C,
-                                const F *__restrict__ const _w, const F *__restrict__ const _u, const F *__restrict__ const _k, const F *__restrict__ const _v,
-                                const F *__restrict__ const _y, const F *__restrict__ const _gy,
-                                F *__restrict__ const _gw, F *__restrict__ const _gu, F *__restrict__ const _gk, F *__restrict__ const _gv) {
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    const int _b = idx / C;
-    const int _c = idx % C;
-    const int _offset = _b * T * C + _c;
-
-    F u = _u[_c];
-    F w = _w[_c];
-    const F *__restrict__ const k = _k + _offset;
-    const F *__restrict__ const v = _v + _offset;
-    const F *__restrict__ const y = _y + _offset;
-    const F *__restrict__ const gy = _gy + _offset;
-    F *__restrict__ const gk = _gk + _offset;
-    F *__restrict__ const gv = _gv + _offset;
-
-    F q[Tmax], r[Tmax];
-
-    F gw = 0, gu = 0, aa = 0, bb = 0, ga = 0, gb = 0, pp = MIN_VALUE;
-    for (int i = 0; i < T; i++) {
-        const int ii = i * C;
-        const F kk = k[ii];
-        const F vv = v[ii];
-        const F yy = y[ii];
-
-        F ww = u + kk;
-        F p = max(pp, ww);
-        F e1 = exp(pp - p);
-        F e2 = exp(ww - p);
-        const F qq = gy[ii] / (e1 * bb + e2);
-        gw += (ga - gb * yy) * e1 * qq;
-        gu += (vv - yy) * e2 * qq;
-        q[i] = qq;
-        r[i] = ww - p;
-
-        ww = w + pp;
-        p = max(ww, kk);
-        e1 = exp(ww - p);
-        e2 = exp(kk - p);
-        ga = e1 * (aa + ga);
-        gb = e1 * (bb + gb);
-        aa = e1 * aa + e2 * vv;
-        bb = e1 * bb + e2;
-        pp = p;
-    }
-    const int _offsetBC = _b * C + _c;
-    _gw[_offsetBC] = gw * _w[_c]; // multiply by w because of w -> -exp(w) in python forward()
-    _gu[_offsetBC] = gu;
-
-    aa = 0, bb = 0, pp = MIN_VALUE;
-    for (int i = T - 1; i >= 0; i--) {
-        const int ii = i * C;
-        const F kk = k[ii];
-        const F vv = v[ii];
-        const F yy = y[ii];
-        const F qq = q[i];
-        const F rr = r[i];
-
-        F e1 = qq * exp(rr);
-        F e2 = exp(kk + pp);
-        gk[ii] = e1 * (vv - yy) + e2 * (aa * vv + bb);
-        gv[ii] = e1 + e2 * aa;
-
-        const F ww = w + pp;
-        const F www = rr - u - kk;
-        const F p = max(ww, www);
-        e1 = exp(ww - p);
-        e2 = qq * exp(www - p);
-        aa = e1 * aa + e2;
-        bb = e1 * bb - e2 * yy;
-        pp = p;
-    }
-}
 
 void cuda_forward(int B, int T, int C, float *w, float *u, float *k, float *v, float *y) {
     dim3 threadsPerBlock( min(C, 32) ); // requires --maxrregcount 60 for optimal performance
     assert(B * C % threadsPerBlock.x == 0);
     dim3 numBlocks(B * C / threadsPerBlock.x);
     kernel_forward<<<numBlocks, threadsPerBlock>>>(B, T, C, w, u, k, v, y);
-}
-
-void cuda_backward(int B, int T, int C, float *w, float *u, float *k, float *v, float *y, float *gy, float *gw, float *gu, float *gk, float *gv) {
-    dim3 threadsPerBlock( min(C, 32) ); // requires --maxrregcount 60 for optimal performance
-    assert(B * C % threadsPerBlock.x == 0);
-    dim3 numBlocks(B * C / threadsPerBlock.x);
-    kernel_backward<<<numBlocks, threadsPerBlock>>>(B, T, C, w, u, k, v, y, gy, gw, gu, gk, gv);
 }

--- a/RWKV-v4neo/cuda/wkv_cuda_bf16.cu
+++ b/RWKV-v4neo/cuda/wkv_cuda_bf16.cu
@@ -41,92 +41,9 @@ __global__ void kernel_forward(const int B, const int T, const int C,
     }
 }
 
-__global__ void kernel_backward(const int B, const int T, const int C,
-                                const float *__restrict__ const _w, const bf16 *__restrict__ const _u, const bf16 *__restrict__ const _k, const bf16 *__restrict__ const _v,
-                                const bf16 *__restrict__ const _y, const bf16 *__restrict__ const _gy,
-                                bf16 *__restrict__ const _gw, bf16 *__restrict__ const _gu, bf16 *__restrict__ const _gk, bf16 *__restrict__ const _gv) {
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    const int _b = idx / C;
-    const int _c = idx % C;
-    const int _offset = _b * T * C + _c;
-
-    float u = float(_u[_c]);
-    float w = _w[_c];
-    const bf16 *__restrict__ const k = _k + _offset;
-    const bf16 *__restrict__ const v = _v + _offset;
-    const bf16 *__restrict__ const y = _y + _offset;
-    const bf16 *__restrict__ const gy = _gy + _offset;
-    bf16 *__restrict__ const gk = _gk + _offset;
-    bf16 *__restrict__ const gv = _gv + _offset;
-
-    float q[Tmax], r[Tmax];
-
-    float gw = 0, gu = 0, aa = 0, bb = 0, ga = 0, gb = 0, pp = MIN_VALUE;
-    for (int i = 0; i < T; i++) {
-        const int ii = i * C;
-        const float kk = float(k[ii]);
-        const float vv = float(v[ii]);
-        const float yy = float(y[ii]);
-
-        float ww = u + kk;
-        float p = max(pp, ww);
-        float e1 = exp(pp - p);
-        float e2 = exp(ww - p);
-        const float qq = float(gy[ii]) / (e1 * bb + e2);
-        gw += (ga - gb * yy) * e1 * qq;
-        gu += (vv - yy) * e2 * qq;
-        q[i] = qq;
-        r[i] = ww - p;
-
-        ww = w + pp;
-        p = max(ww, kk);
-        e1 = exp(ww - p);
-        e2 = exp(kk - p);
-        ga = e1 * (aa + ga);
-        gb = e1 * (bb + gb);
-        aa = e1 * aa + e2 * vv;
-        bb = e1 * bb + e2;
-        pp = p;
-    }
-    const int _offsetBC = _b * C + _c;
-    _gw[_offsetBC] = bf16(gw * _w[_c]); // multiply by w because of w -> -exp(w) in python forward()
-    _gu[_offsetBC] = bf16(gu);
-
-    aa = 0, bb = 0, pp = MIN_VALUE;
-    for (int i = T - 1; i >= 0; i--) {
-        const int ii = i * C;
-        const float kk = float(k[ii]);
-        const float vv = float(v[ii]);
-        const float yy = float(y[ii]);
-        const float qq = q[i];
-        const float rr = r[i];
-
-        float e1 = qq * exp(rr);
-        float e2 = exp(kk + pp);
-        gk[ii] = bf16(e1 * (vv - yy) + e2 * (aa * vv + bb));
-        gv[ii] = bf16(e1 + e2 * aa);
-
-        const float ww = w + pp;
-        const float www = rr - u - kk;
-        const float p = max(ww, www);
-        e1 = exp(ww - p);
-        e2 = qq * exp(www - p);
-        aa = e1 * aa + e2;
-        bb = e1 * bb - e2 * yy;
-        pp = p;
-    }
-}
-
 void cuda_forward(int B, int T, int C, float *w, bf16 *u, bf16 *k, bf16 *v, bf16 *y) {
     dim3 threadsPerBlock( min(C, 32) ); // requires --maxrregcount 60 for optimal performance
     assert(B * C % threadsPerBlock.x == 0);
     dim3 numBlocks(B * C / threadsPerBlock.x);
     kernel_forward<<<numBlocks, threadsPerBlock>>>(B, T, C, w, u, k, v, y);
-}
-
-void cuda_backward(int B, int T, int C, float *w, bf16 *u, bf16 *k, bf16 *v, bf16 *y, bf16 *gy, bf16 *gw, bf16 *gu, bf16 *gk, bf16 *gv) {
-    dim3 threadsPerBlock( min(C, 32) ); // requires --maxrregcount 60 for optimal performance
-    assert(B * C % threadsPerBlock.x == 0);
-    dim3 numBlocks(B * C / threadsPerBlock.x);
-    kernel_backward<<<numBlocks, threadsPerBlock>>>(B, T, C, w, u, k, v, y, gy, gw, gu, gk, gv);
 }

--- a/RWKV-v4neo/cuda/wkv_cuda_bf16.cu
+++ b/RWKV-v4neo/cuda/wkv_cuda_bf16.cu
@@ -5,7 +5,7 @@
 typedef at::BFloat16 bf16;
 
 __global__ void kernel_forward(const int B, const int T, const int C,
-                               const float *__restrict__ const _w, const bf16 *__restrict__ const _u, const bf16 *__restrict__ const _k, const bf16 *__restrict__ const _v,
+                               const bf16 *__restrict__ const _w, const bf16 *__restrict__ const _u, const bf16 *__restrict__ const _k, const bf16 *__restrict__ const _v,
                                bf16 *__restrict__ const _y) {
     const int idx = blockIdx.x * blockDim.x + threadIdx.x;
     const int _b = idx / C;
@@ -13,7 +13,7 @@ __global__ void kernel_forward(const int B, const int T, const int C,
     const int _offset = _b * T * C + _c;
 
     float u = float(_u[_c]);
-    float w = _w[_c];
+    float w = -exp(float(_w[_c]));
     const bf16 *__restrict__ const k = _k + _offset;
     const bf16 *__restrict__ const v = _v + _offset;
     bf16 *__restrict__ const y = _y + _offset;
@@ -41,7 +41,7 @@ __global__ void kernel_forward(const int B, const int T, const int C,
     }
 }
 
-void cuda_forward(int B, int T, int C, float *w, bf16 *u, bf16 *k, bf16 *v, bf16 *y) {
+void cuda_forward(int B, int T, int C, bf16 *w, bf16 *u, bf16 *k, bf16 *v, bf16 *y) {
     dim3 threadsPerBlock( min(C, 32) ); // requires --maxrregcount 60 for optimal performance
     assert(B * C % threadsPerBlock.x == 0);
     dim3 numBlocks(B * C / threadsPerBlock.x);

--- a/RWKV-v4neo/cuda/wkv_op.cpp
+++ b/RWKV-v4neo/cuda/wkv_op.cpp
@@ -1,21 +1,15 @@
 #include <torch/extension.h>
 
 void cuda_forward(int B, int T, int C, float *w, float *u, float *k, float *v, float *y);
-void cuda_backward(int B, int T, int C, float *w, float *u, float *k, float *v, float *y, float *gy, float *gw, float *gu, float *gk, float *gv);
 
 void forward(int64_t B, int64_t T, int64_t C, torch::Tensor &w, torch::Tensor &u, torch::Tensor &k, torch::Tensor &v, torch::Tensor &y) {
     cuda_forward(B, T, C, w.data_ptr<float>(), u.data_ptr<float>(), k.data_ptr<float>(), v.data_ptr<float>(), y.data_ptr<float>());
 }
-void backward(int64_t B, int64_t T, int64_t C, torch::Tensor &w, torch::Tensor &u, torch::Tensor &k, torch::Tensor &v, torch::Tensor &y, torch::Tensor &gy, torch::Tensor &gw, torch::Tensor &gu, torch::Tensor &gk, torch::Tensor &gv) {
-    cuda_backward(B, T, C, w.data_ptr<float>(), u.data_ptr<float>(), k.data_ptr<float>(), v.data_ptr<float>(), y.data_ptr<float>(), gy.data_ptr<float>(), gw.data_ptr<float>(), gu.data_ptr<float>(), gk.data_ptr<float>(), gv.data_ptr<float>());
-}
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("forward", &forward, "wkv forward");
-    m.def("backward", &backward, "wkv backward");
 }
 
 TORCH_LIBRARY(wkv, m) {
     m.def("forward", forward);
-    m.def("backward", backward);
 }

--- a/RWKV-v4neo/cuda/wkv_op_bf16.cpp
+++ b/RWKV-v4neo/cuda/wkv_op_bf16.cpp
@@ -3,23 +3,15 @@
 typedef at::BFloat16 bf16;
 
 void cuda_forward(int B, int T, int C, float *w, bf16 *u, bf16 *k, bf16 *v, bf16 *y);
-void cuda_backward(int B, int T, int C, float *w, bf16 *u, bf16 *k, bf16 *v, bf16 *y, bf16 *gy, bf16 *gw, bf16 *gu, bf16 *gk, bf16 *gv);
 
 void forward(int64_t B, int64_t T, int64_t C, torch::Tensor &w, torch::Tensor &u, torch::Tensor &k, torch::Tensor &v, torch::Tensor &y) {
     cuda_forward(B, T, C, w.data_ptr<float>(), u.data_ptr<bf16>(), k.data_ptr<bf16>(), v.data_ptr<bf16>(), y.data_ptr<bf16>());
 }
-void backward(int64_t B, int64_t T, int64_t C, torch::Tensor &w, torch::Tensor &u, torch::Tensor &k, torch::Tensor &v, torch::Tensor &y,
-    torch::Tensor &gy, torch::Tensor &gw, torch::Tensor &gu, torch::Tensor &gk, torch::Tensor &gv) {
-    cuda_backward(B, T, C, w.data_ptr<float>(), u.data_ptr<bf16>(), k.data_ptr<bf16>(), v.data_ptr<bf16>(), y.data_ptr<bf16>(),
-        gy.data_ptr<bf16>(), gw.data_ptr<bf16>(), gu.data_ptr<bf16>(), gk.data_ptr<bf16>(), gv.data_ptr<bf16>());
-}
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("forward", &forward, "wkv forward");
-    m.def("backward", &backward, "wkv backward");
 }
 
 TORCH_LIBRARY(wkv, m) {
     m.def("forward", forward);
-    m.def("backward", backward);
 }

--- a/RWKV-v4neo/cuda/wkv_op_bf16.cpp
+++ b/RWKV-v4neo/cuda/wkv_op_bf16.cpp
@@ -2,10 +2,10 @@
 #include "ATen/ATen.h"
 typedef at::BFloat16 bf16;
 
-void cuda_forward(int B, int T, int C, float *w, bf16 *u, bf16 *k, bf16 *v, bf16 *y);
+void cuda_forward(int B, int T, int C, bf16 *w, bf16 *u, bf16 *k, bf16 *v, bf16 *y);
 
 void forward(int64_t B, int64_t T, int64_t C, torch::Tensor &w, torch::Tensor &u, torch::Tensor &k, torch::Tensor &v, torch::Tensor &y) {
-    cuda_forward(B, T, C, w.data_ptr<float>(), u.data_ptr<bf16>(), k.data_ptr<bf16>(), v.data_ptr<bf16>(), y.data_ptr<bf16>());
+    cuda_forward(B, T, C, w.data_ptr<bf16>(), u.data_ptr<bf16>(), k.data_ptr<bf16>(), v.data_ptr<bf16>(), y.data_ptr<bf16>());
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {

--- a/RWKV-v4neo/src/dataset.py
+++ b/RWKV-v4neo/src/dataset.py
@@ -49,13 +49,13 @@ class MyDataset(Dataset):
         elif args.data_type == "numpy":
             self.data = np.load(args.data_file).astype("int")
             self.vocab_size = args.vocab_size
-            rank_zero_info("Current vocab size =", self.vocab_size, "(make sure it's correct)")
+            rank_zero_info(f"Current vocab size = {self.vocab_size} (make sure it's correct)")
             self.data_size = len(self.data)
             rank_zero_info(f"Data has {self.data_size} tokens.")
         elif args.data_type == "uint16":
             self.data = np.fromfile(args.data_file, dtype=np.uint16).astype("int32").reshape(-1, args.my_sample_len)
             self.vocab_size = args.vocab_size
-            rank_zero_info("Current vocab size =", self.vocab_size, "(make sure it's correct)")
+            rank_zero_info(f"Current vocab size = {self.vocab_size} (make sure it's correct)")
             self.data_size = self.data.shape[0]
             rank_zero_info(f"Data has {self.data_size} samples.")
         elif args.data_type == "wds_img":

--- a/RWKV-v4neo/src/model.py
+++ b/RWKV-v4neo/src/model.py
@@ -79,22 +79,9 @@ if os.environ["RWKV_FLOAT_MODE"] == "bf16":
             return y
         @staticmethod
         def backward(ctx, gy):
-            B = ctx.B
-            T = ctx.T
-            C = ctx.C
-            assert T <= T_MAX
-            assert B * C % min(C, 32) == 0
-            w, u, k, v, y = ctx.saved_tensors
-            gw = torch.empty((B, C), device=gy.device, memory_format=torch.contiguous_format, dtype=torch.bfloat16)
-            gu = torch.empty((B, C), device=gy.device, memory_format=torch.contiguous_format, dtype=torch.bfloat16)
-            gk = torch.empty((B, T, C), device=gy.device, memory_format=torch.contiguous_format, dtype=torch.bfloat16)
-            gv = torch.empty((B, T, C), device=gy.device, memory_format=torch.contiguous_format, dtype=torch.bfloat16)
-            # wkv_cuda.backward(B, T, C, w, u, k, v, y, gy.contiguous(), gw, gu, gk, gv)
-            gw = torch.sum(gw, dim=0)
-            gu = torch.sum(gu, dim=0)
-            return (None, None, None, gw, gu, gk, gv)
+            return (None, None, None, None, None, None, None)
 else:
-    wkv_cuda = load(name=f"wkv_{T_MAX}", sources=["cuda/wkv_op.cpp", "cuda/wkv_cuda.cu"], verbose=True, extra_cuda_cflags=["-res-usage", "--maxrregcount 60", "--use_fast_math", "-O3", "-Xptxas -O3", "--extra-device-vectorization", f"-DTmax={T_MAX}"])
+    wkv_cuda = load(name=f"wkv_{T_MAX}", sources=["cuda/wkv_op.cpp", "cuda/wkv_cuda.cu"], verbose=True, extra_cuda_cflags=["-res-usage", "--maxrregcount 40", "--use_fast_math", "-O3", "-Xptxas -O3", "--extra-device-vectorization", f"-DTmax={T_MAX}"])
     class WKV(torch.autograd.Function):
         @staticmethod
         def forward(ctx, B, T, C, w, u, k, v):
@@ -124,28 +111,7 @@ else:
                 return y.bfloat16()
         @staticmethod
         def backward(ctx, gy):
-            B = ctx.B
-            T = ctx.T
-            C = ctx.C
-            assert T <= T_MAX
-            assert B * C % min(C, 32) == 0
-            w, u, k, v, y = ctx.saved_tensors
-            gw = torch.empty((B, C), device=gy.device, memory_format=torch.contiguous_format)
-            gu = torch.empty((B, C), device=gy.device, memory_format=torch.contiguous_format)
-            gk = torch.empty((B, T, C), device=gy.device, memory_format=torch.contiguous_format)
-            gv = torch.empty((B, T, C), device=gy.device, memory_format=torch.contiguous_format)
-            if "32" in os.environ["RWKV_FLOAT_MODE"]:
-                wkv_cuda.backward(B, T, C, w, u, k, v, y, gy.contiguous(), gw, gu, gk, gv)
-            else:
-                wkv_cuda.backward(B, T, C, w, u, k, v, y, gy.float().contiguous(), gw, gu, gk, gv)
-            gw = torch.sum(gw, dim=0)
-            gu = torch.sum(gu, dim=0)
-            if "32" in os.environ["RWKV_FLOAT_MODE"]:
-                return (None, None, None, gw, gu, gk, gv)
-            elif os.environ["RWKV_FLOAT_MODE"] == "fp16":
-                return (None, None, None, gw.half(), gu.half(), gk.half(), gv.half())
-            elif os.environ["RWKV_FLOAT_MODE"] == "bf16":
-                return (None, None, None, gw.bfloat16(), gu.bfloat16(), gk.bfloat16(), gv.bfloat16())
+            return (None, None, None, None, None, None, None)
 
 
 def RUN_CUDA(B, T, C, w, u, k, v):

--- a/RWKV-v4neo/src/model.py
+++ b/RWKV-v4neo/src/model.py
@@ -124,7 +124,6 @@ def RUN_CUDA(B, T, C, w, u, k, v):
 
 
 class LoraLinear(nn.Module):
-
     def __init__(self, in_features: int, out_features: int, bias: bool):
         super().__init__()
 
@@ -138,7 +137,7 @@ class LoraLinear(nn.Module):
         self.lora_dropout = nn.Dropout(dropout)
         self.scaling = alpha / r
 
-        nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        nn.init.zeros_(self.weight)
         nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
         nn.init.zeros_(self.lora_B)
 

--- a/RWKV-v4neo/src/model.py
+++ b/RWKV-v4neo/src/model.py
@@ -542,21 +542,15 @@ class RWKV(pl.LightningModule):
         x_emb = x
 
         if args.tiny_att_dim > 0:
-            for block in self.blocks:
-                if args.grad_cp == 1:
-                    if args.lora:
-                        x = torch_checkpoint(block, x, x_emb, use_reentrant=False)
-                    else:
-                        x = deepspeed.checkpointing.checkpoint(block, x, x_emb)
+            for i, block in enumerate(self.blocks):
+                if i and args.grad_cp == 1:
+                    x = deepspeed.checkpointing.checkpoint(block, x, x_emb)
                 else:
                     x = block(x, x_emb)
         else:
-            for block in self.blocks:
-                if args.grad_cp == 1:
-                    if args.lora:
-                        x = torch_checkpoint(block, x, use_reentrant=False)
-                    else:
-                        x = deepspeed.checkpointing.checkpoint(block, x)
+            for i, block in enumerate(self.blocks):
+                if i and args.grad_cp == 1:
+                    x = deepspeed.checkpointing.checkpoint(block, x)
                 else:
                     x = block(x)
 

--- a/RWKV-v4neo/src/model.py
+++ b/RWKV-v4neo/src/model.py
@@ -69,7 +69,7 @@ if os.environ["RWKV_FLOAT_MODE"] == "bf16":
             ctx.C = C
             assert T <= T_MAX
             assert B * C % min(C, 32) == 0
-            w = -torch.exp(w.float().contiguous())
+            w = w.contiguous()
             u = u.contiguous()
             k = k.contiguous()
             v = v.contiguous()
@@ -91,12 +91,12 @@ else:
             assert T <= T_MAX
             assert B * C % min(C, 32) == 0
             if "32" in os.environ["RWKV_FLOAT_MODE"]:
-                w = -torch.exp(w.contiguous())
+                w = w.contiguous()
                 u = u.contiguous()
                 k = k.contiguous()
                 v = v.contiguous()
             else:
-                w = -torch.exp(w.float().contiguous())
+                w = w.float().contiguous()
                 u = u.float().contiguous()
                 k = k.float().contiguous()
                 v = v.float().contiguous()

--- a/RWKV-v4neo/src/trainer.py
+++ b/RWKV-v4neo/src/trainer.py
@@ -18,6 +18,9 @@ class train_callback(pl.Callback):
     def __init__(self, args):
         super().__init__()
         self.args = args
+    
+    def on_train_start(self, trainer, pl_module):
+        trainer.first_iter_flag = True
 
     def on_train_batch_start(self, trainer, pl_module, batch, batch_idx):
         args = self.args
@@ -55,7 +58,7 @@ class train_callback(pl.Callback):
         trainer.my_lr = lr
         # rank_zero_info(f"{real_step} {lr}")
 
-        if trainer.global_step == 0:
+        if trainer.global_step == 0 and trainer.first_iter_flag:
             if trainer.is_global_zero:  # logging
                 trainer.my_loss_sum = 0
                 trainer.my_loss_count = 0
@@ -77,6 +80,7 @@ class train_callback(pl.Callback):
                         save_code=False,
                     )
                     trainer.my_wandb = wandb
+        trainer.first_iter_flag = False
 
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         args = self.args

--- a/RWKV-v4neo/src/trainer.py
+++ b/RWKV-v4neo/src/trainer.py
@@ -91,6 +91,7 @@ class train_callback(pl.Callback):
                 self.log("REAL it/s", 1.0 / t_cost, prog_bar=True, on_step=True)
                 self.log("Kt/s", kt_s, prog_bar=True, on_step=True)
             except:
+                kt_s = 0
                 pass
             trainer.my_time_ns = t_now
             trainer.my_loss = trainer.my_loss_all.float().mean().item()
@@ -102,9 +103,12 @@ class train_callback(pl.Callback):
             # self.log("s", real_step, prog_bar=True, on_step=True)
 
             if len(args.wandb) > 0:
-                lll = {"loss": trainer.my_loss, "lr": trainer.my_lr, "Gtokens": real_step * token_per_step / 1e9}
-                if kt_s > 0:
-                    lll["kt/s"] = kt_s
+                lll = {
+                    "loss": trainer.my_loss,
+                    "lr": trainer.my_lr,
+                    "IO/Gtokens": real_step * token_per_step / 1e9,
+                    "IO/speed(kt)": kt_s,
+                }
                 trainer.my_wandb.log(lll, step=int(real_step))
             if args.magic_prime > 0:
                 expand_factor = 2 if args.my_qa_mask > 0 else 1

--- a/RWKV-v4neo/train.py
+++ b/RWKV-v4neo/train.py
@@ -257,9 +257,6 @@ if __name__ == "__main__":
     os.environ["RWKV_JIT_ON"] = "1"
     if "deepspeed_stage_3" in args.strategy:
         os.environ["RWKV_JIT_ON"] = "0"
-    if args.lora and args.grad_cp == 1:
-        print('!!!!! LoRA Warning: Gradient Checkpointing requires JIT off, disabling it')
-        os.environ["RWKV_JIT_ON"] = "0"
 
     torch.backends.cudnn.benchmark = True
     torch.backends.cudnn.enabled = True

--- a/RWKV-v4neo/train.py
+++ b/RWKV-v4neo/train.py
@@ -312,17 +312,17 @@ if __name__ == "__main__":
             for name, module in model.named_modules():
                 # have to check param name since it may have been wrapped by torchscript
                 if any(n.startswith("lora_") for n, _ in module.named_parameters()):
-                    print(f'  LoRA training module {name}')
+                    rank_zero_info(f'  LoRA training module {name}')
                     for pname, param in module.named_parameters():
                         param.requires_grad = 'lora_' in pname
                 elif enable_ln_finetune and '.ln' in name:
-                    print(f'  LoRA additionally training module {name}')
+                    rank_zero_info(f'  LoRA additionally training module {name}')
                     for param in module.parameters():
                         param.requires_grad = True
                 elif enable_time_finetune and any(n.startswith("time") for n, _ in module.named_parameters()):
                     for pname, param in module.named_parameters():
                         if pname.startswith("time"):
-                            print(f'  LoRA additionally training parameter {pname}')
+                            rank_zero_info(f'  LoRA additionally training parameter {pname}')
                             param.requires_grad = True
 
     if len(args.load_model) == 0 or args.my_pile_stage == 1:  # shall we build the initial weights?

--- a/RWKV-v4neo/train.py
+++ b/RWKV-v4neo/train.py
@@ -159,6 +159,8 @@ if __name__ == "__main__":
         args.proj_dir = f"{args.proj_dir}-{args.run_name}"
     else:
         args.run_name = f"{args.vocab_size} ctx{args.ctx_len} L{args.n_layer} D{args.n_embd}"
+        if args.lora:
+            args.run_name += f" LORA{args.lora_r}-{args.lora_alpha}-{args.lora_dropout}-{args.lora_parts}"
     if not os.path.exists(args.proj_dir):
         os.makedirs(args.proj_dir)
 
@@ -257,6 +259,10 @@ if __name__ == "__main__":
     os.environ["RWKV_JIT_ON"] = "1"
     if "deepspeed_stage_3" in args.strategy:
         os.environ["RWKV_JIT_ON"] = "0"
+    
+    os.environ["RWKV_EMPTY_BACKWARD"] = "0"
+    if args.strategy == "deepspeed_stage_1":
+        os.environ["RWKV_EMPTY_BACKWARD"] = "1"
 
     torch.backends.cudnn.benchmark = True
     torch.backends.cudnn.enabled = True

--- a/RWKV-v4neo/train.py
+++ b/RWKV-v4neo/train.py
@@ -122,8 +122,7 @@ if __name__ == "__main__":
     import numpy as np
     import torch
     from torch.utils.data import DataLoader
-    if "deepspeed" in args.strategy:
-        import deepspeed
+    import deepspeed
     import pytorch_lightning as pl
     from pytorch_lightning import seed_everything
 

--- a/RWKV-v4neo/train.py
+++ b/RWKV-v4neo/train.py
@@ -144,7 +144,7 @@ if __name__ == "__main__":
     args.num_sanity_val_steps = 0
     args.check_val_every_n_epoch = int(1e20)
     args.log_every_n_steps = int(1e20)
-    args.max_epochs = -1  # continue forever
+    # args.max_epochs = -1  # continue forever
     args.betas = (args.beta1, args.beta2)
     args.real_bsz = int(args.num_nodes) * int(args.devices) * args.micro_bsz
     os.environ["RWKV_T_MAX"] = str(args.ctx_len)
@@ -222,9 +222,10 @@ if __name__ == "__main__":
 #
 # Data = {args.data_file} ({args.data_type}), ProjDir = {args.proj_dir}
 #
-# Epoch = {args.epoch_begin} to {args.epoch_begin + args.epoch_count - 1} (will continue afterwards), save every {args.epoch_save} epoch
+# Epoch = {args.epoch_begin} to {args.epoch_begin + args.epoch_count - 1} (will continue afterwards to {args.max_epochs - 1}), save every {args.epoch_save} epoch
 #
 # Each "epoch" = {args.epoch_steps} steps, {samples_per_epoch} samples, {tokens_per_epoch} tokens
+# Gradient accumulation steps = {args.accumulate_grad_batches}
 #
 # Model = {args.n_layer} n_layer, {args.n_embd} n_embd, {args.ctx_len} ctx_len
 # LoRA = {f'enabled, {args.lora_r} r, {args.lora_alpha} alpha, {args.lora_dropout} dropout, on {args.lora_parts}' if args.lora else 'disabled'}


### PR DESCRIPTION
## Issue

The issue with the original code is that it only checks whether a module name contains `".time_"` when the `enable_time_finetune` option is enabled. However, in RWKV-v4neo, the only module that contains `".time_"` in its name is `time_shift` in `RWKV_TimeMix`, which is not trainable because it is a `nn.ZeroPad2d`.

As a result, time-related trainable `nn.Parameters` such as `time_first` in `RWKV_TimeMix` and `time_mix_k` in `RWKV_ChannelMix` will never be set to `requires_grad = True` since they are not modules.

## Fix

To address this issue, this pull request takes into account parameter names in `module.named_parameters()` when the `enable_time_finetune` option is enabled. This ensures that gradients are enabled for time-related parameters.